### PR TITLE
feat(matchingPairs): add prototype with idle state, timer, and shared…

### DIFF
--- a/src/app/arcade/matching-pairs/page.module.css
+++ b/src/app/arcade/matching-pairs/page.module.css
@@ -1,0 +1,13 @@
+.timer {
+  font-size: 1.5rem;
+}
+
+.cardsRowContainer {
+  width: 440px;
+}
+
+.cardsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}

--- a/src/app/arcade/matching-pairs/page.tsx
+++ b/src/app/arcade/matching-pairs/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import styles from "./page.module.css";
+
+import type { GameStatus } from "@/types";
+import { startIfIdle } from "@/utils";
+
+import Card from "@/features/matchingPairs/components/Card";
+import RestartButton from "@/components/RestartButton";
+
+type MemoryCard = {
+  id: string;
+  value: any;
+};
+
+const VALUES = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5];
+const TOTAL_TIME = 60;
+
+function MatchingPairsPage() {
+  const [deck, setDeck] = useState<MemoryCard[]>(() => arrayToDeck(VALUES));
+  const [openCards, setOpenCards] = useState<MemoryCard[]>([]);
+  const [guessedCards, setGuessedCards] = useState<MemoryCard[]>([]);
+  const [isBusy, setIsBusy] = useState(false);
+  const [gameStatus, setGameStatus] = useState<GameStatus>("idle");
+  const [timeLeft, setTimeLeft] = useState(TOTAL_TIME);
+
+  useEffect(() => {
+    setDeck((prev) => shuffleDeck(prev));
+  }, []);
+
+  useEffect(() => {
+    if (gameStatus !== "running") return;
+    if (!timeLeft) {
+      setGameStatus("lost");
+      return;
+    }
+
+    const id = setInterval(() => setTimeLeft((t) => t - 1), 1000);
+    return () => clearInterval(id);
+  }, [gameStatus, timeLeft]);
+
+  function shuffleDeck(array: any[]) {
+    const copy = [...array];
+    for (let i = copy.length - 1; i >= 1; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [copy[i], copy[j]] = [copy[j], copy[i]];
+    }
+    return copy;
+  }
+
+  function arrayToDeck(array: any[]) {
+    const objectList = [];
+    for (let i = 0; i < array.length; i++) {
+      objectList.push({ value: array[i], id: `${array[i]}-${i}` });
+    }
+    return objectList;
+  }
+
+  function checkTentativeWin(array: MemoryCard[]) {
+    if (array.length === deck.length) {
+      setGameStatus("won");
+      setTimeLeft((t) => t);
+    }
+  }
+
+  function checkTentativeGuess(cardArray: MemoryCard[]) {
+    if (cardArray[0].value === cardArray[1].value) {
+      const nextGuessedCards = [...guessedCards, cardArray[0], cardArray[1]];
+      setGuessedCards(nextGuessedCards);
+      checkTentativeWin(nextGuessedCards);
+      setOpenCards([]);
+      return;
+    }
+
+    setIsBusy(true);
+    setTimeout(() => {
+      setOpenCards([]);
+      setIsBusy(false);
+    }, 600);
+    return;
+  }
+
+  function handleClick({ id, value }: MemoryCard) {
+    startIfIdle(gameStatus, setGameStatus);
+    if (isBusy) return;
+    if (
+      openCards.some((card) => card.id === id) ||
+      guessedCards.some((card) => card.id === id)
+    )
+      return;
+    const nextOpenCards = [...openCards, { id, value }];
+    setOpenCards(nextOpenCards);
+
+    if (nextOpenCards.length === 2) {
+      checkTentativeGuess(nextOpenCards);
+    }
+  }
+
+  function restart() {
+    setDeck(() => shuffleDeck(deck));
+    setOpenCards([]);
+    setGuessedCards([]);
+    setTimeLeft(TOTAL_TIME);
+    setGameStatus("idle");
+  }
+
+  const isIdle = gameStatus === "idle";
+  const isRunning = gameStatus === "running" || gameStatus === "idle";
+
+  return (
+    <>
+      <header>
+        <h1>Matching Pairs Game</h1>
+      </header>
+      <main>
+        <span className={styles.timer}>{timeLeft}s</span>
+        <div className={styles.cardsRowContainer}>
+          <div className={styles.cardsRow}>
+            {deck.map(({ value, id }) => {
+              return (
+                <Card
+                  value={value}
+                  key={id}
+                  id={id}
+                  isFlipped={openCards.some((card) => card.id === id)}
+                  isMatched={guessedCards.some((card) => card.id === id)}
+                  onClick={() => handleClick({ value, id })}
+                />
+              );
+            })}
+          </div>
+        </div>
+        <p>
+          <em>
+            {gameStatus === "won" && `You won with ${timeLeft} seconds left!`}
+          </em>
+        </p>
+        <p>
+          <strong>{isIdle && "Select a card to start playing"}</strong>
+          <strong>{!isRunning && "Game over"}</strong>
+        </p>
+        {!isRunning && <RestartButton onClick={restart} />}
+      </main>
+    </>
+  );
+}
+
+export default MatchingPairsPage;

--- a/src/app/arcade/snake/page.tsx
+++ b/src/app/arcade/snake/page.tsx
@@ -26,6 +26,7 @@ function SnakePage() {
         className={styles.gameBoard}
       ></canvas>
       <p>
+        <strong>{game.isIdle && "Press any button to start the game"}</strong>
         <strong>{!game.isRunning && "Game over"}</strong>
       </p>
       {!game.isRunning && <RestartButton onClick={game.restart} />}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ export default function Home() {
       <div className={styles.linkContainer}>
         <Link href="/arcade/hangman">Hangman</Link>
         <Link href="/arcade/snake">Snake</Link>
+        <Link href="/arcade/matching-pairs">Matching Pairs</Link>
       </div>
     </div>
   );

--- a/src/features/matchingPairs/components/Card/Card.module.css
+++ b/src/features/matchingPairs/components/Card/Card.module.css
@@ -1,0 +1,14 @@
+.card {
+  width: 80px;
+  height: 200px;
+  border: 1px solid white;
+}
+
+.cardBack {
+  background-color: rgb(1, 31, 57);
+}
+
+.cardFace {
+  background-color: white;
+  color: black;
+}

--- a/src/features/matchingPairs/components/Card/Card.tsx
+++ b/src/features/matchingPairs/components/Card/Card.tsx
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import styles from "./Card.module.css";
+
+type Props = {
+  value: any;
+  id: string;
+  isFlipped: boolean;
+  isMatched: boolean;
+  onClick?: () => void;
+};
+
+function Card({ value, id, isFlipped, isMatched, onClick }: Props) {
+  return (
+    <div
+      id={id}
+      className={`${styles.card} ${
+        isFlipped || isMatched ? styles.cardFace : styles.cardBack
+      }`}
+      onClick={onClick}
+    >
+      {(isFlipped || isMatched) && value}
+    </div>
+  );
+}
+
+export default Card;

--- a/src/features/matchingPairs/components/Card/index.ts
+++ b/src/features/matchingPairs/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Card";

--- a/src/features/snake/hooks/useDirection.ts
+++ b/src/features/snake/hooks/useDirection.ts
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from "react";
 import type { Vector, DirectionName } from "../types";
 import type { GameStatus } from "@/types";
+import { startIfIdle } from "@/utils";
 
 function useDirection(
   direction: Vector,
   gameStatus: GameStatus,
+  setGameStatus: (newGameStatus: GameStatus) => void,
   directionsMap: Record<DirectionName, Vector>
 ) {
   const queuedDirection = useRef<Vector | null>(null);
@@ -35,6 +37,9 @@ function useDirection(
     }
 
     function handleKeyDown(event: KeyboardEvent) {
+      if (gameStatus === "idle") {
+        startIfIdle(gameStatus, setGameStatus);
+      }
       if (gameStatus !== "running") return;
       const wanted = chooseDirection(event.key);
       if (!wanted) return;

--- a/src/features/snake/hooks/useSnake.ts
+++ b/src/features/snake/hooks/useSnake.ts
@@ -35,7 +35,7 @@ function useSnake(
     RIGHT: { x: tile, y: 0 },
   };
 
-  const [gameStatus, setGameStatus] = React.useState<GameStatus>("running");
+  const [gameStatus, setGameStatus] = React.useState<GameStatus>("idle");
   const [snakePosition, setSnakePosition] = React.useState<Vector[]>(
     SNAKE_INITIAL_POSITION
   );
@@ -46,7 +46,12 @@ function useSnake(
     DIRECTIONS_MAP.RIGHT
   );
 
-  const queuedDirection = useDirection(direction, gameStatus, DIRECTIONS_MAP);
+  const queuedDirection = useDirection(
+    direction,
+    gameStatus,
+    setGameStatus,
+    DIRECTIONS_MAP
+  );
 
   React.useEffect(() => {
     if (gameStatus !== "running") return;
@@ -91,13 +96,14 @@ function useSnake(
     setFoodPosition(FOOD_INITIAL_POSITION);
     setDirection(DIRECTIONS_MAP.RIGHT);
 
-    setGameStatus("running");
+    setGameStatus("idle");
   }
 
   return {
     snakePosition,
     foodPosition,
-    isRunning: gameStatus === "running",
+    isIdle: gameStatus === "idle",
+    isRunning: gameStatus === "running" || gameStatus === "idle",
     restart,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,3 @@
-type GameStatus = "running" | "won" | "lost";
+type GameStatus = 'idle' | "running" | "won" | "lost";
 
 export type { GameStatus };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,10 @@
+import type { GameStatus } from "./types";
+
+function startIfIdle(
+  gameStatus: GameStatus,
+  setGameStatus: (newGameStatus: GameStatus) => void
+) {
+  if (gameStatus === "idle") setGameStatus("running");
+}
+
+export { startIfIdle };


### PR DESCRIPTION
… helpers

• Implement Matching Pairs page
  – Shuffles deck after hydration to avoid SSR mismatch
  – Idle → running → won/lost game state
  – 60 s countdown timer, restart button
  – Card component with face/back rendering
• Add startIfIdle util and extend GameStatus with "idle" • Snake: integrate idle state; game starts on first key press