### PR TITLE
feat(hangman): refactor game logic into composable hooks

### DIFF
--- a/src/app/arcade/hangman/page.tsx
+++ b/src/app/arcade/hangman/page.tsx
@@ -12,11 +12,13 @@ function HangmanPage() {
   const {
     attempts,
     answer,
-    gameStatus,
     usedLetters,
+    isWon,
+    isLost,
     isRunning,
     handleGuess,
     restart,
+    word,
   } = useHangman();
   return (
     <div className={styles.contentContainer}>
@@ -28,10 +30,13 @@ function HangmanPage() {
         disabled={!isRunning}
       />
       <p>
-        <em>{gameStatus === "won" && "You won!"}</em>
+        <em>{isWon && "You won!"}</em>
       </p>
       <p>
         <strong>{!isRunning && "Game over"}</strong>
+      </p>
+      <p>
+        <strong>{isLost && `The word was ${word}`}</strong>
       </p>
       {!isRunning && <RestartButton onClick={restart} />}
     </div>

--- a/src/features/hangman/data.ts
+++ b/src/features/hangman/data.ts
@@ -1,5 +1,96 @@
+// Word database for Hangman, grouped by difficulty.
+//
+// Easy: 3–4‑letter words
+// Medium: 6–7‑letter words
+// Hard: 9+‑letter words
+
+const WORDS = {
+  easy: [
+    "ant",
+    "bee",
+    "cat",
+    "dog",
+    "ear",
+    "fan",
+    "gym",
+    "hat",
+    "ice",
+    "jam",
+    "kite",
+    "lion",
+    "moon",
+    "nest",
+    "oak",
+    "pig",
+    "rain",
+    "sun",
+    "tree",
+    "urge",
+    "vine",
+    "wolf",
+    "xray",
+    "yarn",
+    "zinc",
+  ],
+
+  medium: [
+    "cactus",
+    "puzzle",
+    "guitar",
+    "planet",
+    "ribbon",
+    "sphinx",
+    "castle",
+    "desert",
+    "jungle",
+    "kingdom",
+    "lantern",
+    "magnet",
+    "nearly",
+    "orange",
+    "pickle",
+    "quartz",
+    "rocket",
+    "stream",
+    "tornado",
+    "walrus",
+    "zephyr",
+    "anchor",
+    "bishop",
+    "circle",
+    "dragon",
+  ],
+
+  hard: [
+    "avalanche",
+    "blueberry",
+    "chocolate",
+    "hemisphere",
+    "impossible",
+    "juxtapose",
+    "kaleidoscope",
+    "labyrinth",
+    "mnemonics",
+    "nightingale",
+    "onomatopoeia",
+    "pneumonia",
+    "quarantine",
+    "rhapsodize",
+    "saxophone",
+    "trapezoid",
+    "underground",
+    "vocabulary",
+    "whimsical",
+    "xylophone",
+    "yellowtail",
+    "archeology",
+    "butterflies",
+    "counterfeit",
+    "earthquake",
+  ],
+};
+
 const KEYS = "QWERTYUIOPASDFGHJKLZXCVBNM";
 const ATTEMPTS = 7;
-const WORD = "HANGMAN";
 
-export { KEYS, ATTEMPTS, WORD };
+export { KEYS, ATTEMPTS, WORDS };

--- a/src/features/hangman/hooks/useAttempts.ts
+++ b/src/features/hangman/hooks/useAttempts.ts
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+function useAttempts(max: number, onLose: () => void) {
+  const [attempts, setAttempts] = useState(max);
+
+  //Wrong guess
+  function consumeAttempt() {
+    setAttempts((prevAttempts) => {
+      const next = prevAttempts - 1;
+      if (next === 0) onLose(); //Check if game is lost
+      return next;
+    });
+  }
+
+  function resetAttempts() {
+    setAttempts(max);
+  }
+
+  return { attempts, consumeAttempt, resetAttempts };
+}
+
+export default useAttempts;

--- a/src/features/hangman/hooks/useKeyboardListener.ts
+++ b/src/features/hangman/hooks/useKeyboardListener.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+function useKeyboardListener(onKey: (key: string) => void, active: boolean) {
+  useEffect(() => {
+    if (!active) return;
+    function handleKeyDown(event: KeyboardEvent) {
+      return onKey(event.key);
+    }
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onKey, active]);
+}
+
+export default useKeyboardListener;

--- a/src/features/hangman/hooks/useWord.ts
+++ b/src/features/hangman/hooks/useWord.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback } from "react";
+
+import { WORDS } from "../data";
+import { getRandomInt } from "../utils";
+import { Difficulty } from "../types";
+
+function useWord(difficulty: Difficulty) {
+  const [usedWords, setUsedWords] = useState<string[]>([]);
+
+  function randomlySelectWord(wordsArray: string[]) {
+    const i = getRandomInt(0, wordsArray.length);
+
+    return wordsArray[i];
+  }
+
+  const getNextWord = useCallback(() => {
+    const bank = WORDS[difficulty];
+
+    let nextWord: string = randomlySelectWord(WORDS[difficulty]);
+
+    while (usedWords.includes(nextWord)) {
+      nextWord = randomlySelectWord(WORDS[difficulty]);
+    }
+
+    nextWord = nextWord.toUpperCase();
+
+    const nextUsedWords = [...usedWords, nextWord];
+
+    bank.length === nextUsedWords.length
+      ? setUsedWords([])
+      : setUsedWords(nextUsedWords);
+
+    console.log(nextWord);
+
+    return nextWord;
+  }, [difficulty]);
+
+  return getNextWord;
+}
+
+export default useWord;

--- a/src/features/hangman/types.ts
+++ b/src/features/hangman/types.ts
@@ -3,4 +3,6 @@ type LetterEntry = {
   isHidden: boolean;
 };
 
-export type { LetterEntry };
+type Difficulty = "easy" | "medium" | "hard";
+
+export type { LetterEntry, Difficulty };

--- a/src/features/hangman/utils.ts
+++ b/src/features/hangman/utils.ts
@@ -1,0 +1,15 @@
+import type { LetterEntry } from "./types";
+
+// Function to convert a word into an array of LetterEntry objects
+function toAnswerArray(word: string): LetterEntry[] {
+  return word.split("").map((letter) => ({ letter, isHidden: true }));
+}
+
+// Function to select a random integer between two values
+function getRandomInt(min: number, max: number) {
+  const minCeiled = Math.ceil(min);
+  const maxFloored = Math.floor(max);
+  return Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled); // The maximum is exclusive and the minimum is inclusive
+}
+
+export { toAnswerArray, getRandomInt };


### PR DESCRIPTION
* **extract hooks**

  * `useAttempts`: encapsulates remaining-attempts counter & loss callback
  * `useKeyboardListener`: centralizes key-press subscription / cleanup

* **add `useWord`**

  * pulls a random word from `WORDS` bank according to selected *difficulty*
  * guarantees no repeats until bucket is exhausted
  * lays groundwork for future UI difficulty selector

* **single source of truth**

  * `answer` array derived from chosen word; `word` kept only for quick look-ups

* **UX improvements**

  * reveal the secret word when the player loses
  * clean restart logic resets attempts, used letters and picks a fresh word

Misc: updated `words.ts` with 25 words per tier and helper `getRandomWord()`.

BREAKING CHANGE: hangman component/page must now call the new hooks (`useAttempts`, `useWord`, `useKeyboardListener`) instead of inline logic.