### PR TITLE
feat: global difficulty system for all arcade games

### DIFF
--- a/src/app/arcade/[game]/layout.tsx
+++ b/src/app/arcade/[game]/layout.tsx
@@ -29,7 +29,7 @@ async function GameLayout({
     <>
       <header>
         <LinkToHub />
-        <h1>{`${gameName} Game`}</h1>
+        <h2>{`${gameName} Game`}</h2>
       </header>
       <main>{children}</main>
     </>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <h1>Next Arcade</h1>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,4 +1,0 @@
-.linkContainer {
-  display: flex;
-  flex-direction: column;
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,10 @@
 import styles from "./page.module.css";
-import Link from "next/link";
+import GameSelector from "@/components/GameSelector";
 
 export default function Home() {
   return (
     <div className={styles.page}>
-      <div className={styles.linkContainer}>
-        <Link href="/arcade/hangman">Hangman</Link>
-        <Link href="/arcade/snake">Snake</Link>
-        <Link href="/arcade/matching-pairs">Matching Pairs</Link>
-      </div>
+      <GameSelector />
     </div>
   );
 }

--- a/src/components/DropdownList/DropdownList.module.css
+++ b/src/components/DropdownList/DropdownList.module.css
@@ -1,0 +1,24 @@
+.dropdownContainer {
+  position: relative;
+  border: 1px solid white;
+  border-radius: 10px;
+  padding: 5px;
+  cursor: pointer;
+}
+
+.dropdown {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 1rem);
+
+  padding: 5px;
+  border: 1px solid white;
+  border-radius: 10px;
+  width: 100%;
+  min-width: 150px;
+}
+
+.list {
+  list-style: none;
+  padding-inline: 0;
+}

--- a/src/components/DropdownList/DropdownList.tsx
+++ b/src/components/DropdownList/DropdownList.tsx
@@ -1,0 +1,69 @@
+import { ReactNode, useRef, useEffect } from "react";
+import styles from "./DropdownList.module.css";
+import LinkButton from "../LinkButton";
+import { transformLabel } from "@/utils";
+
+type Props = {
+  id: string;
+  isOpen: boolean;
+  gameTitle: string;
+  onClick: () => void;
+  children: ReactNode;
+  className?: string;
+};
+
+function DropdownList({
+  isOpen,
+  gameTitle,
+  id,
+  onClick,
+  className,
+  children,
+}: Props) {
+  const difficultyOptions = ["easy", "medium", "hard"];
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        onClick(); // Parent's toggler will turn `isOpen` → false
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onClick]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`${styles.dropdownContainer} ${className}`}
+      id={id}
+      onClick={onClick}
+      tabIndex={0}
+    >
+      {children}
+      {isOpen && (
+        <div className={styles.dropdown}>
+          <span>Select difficulty:</span>
+          <ul className={styles.list}>
+            {difficultyOptions.map((option, index) => (
+              <li key={index}>
+                <LinkButton href={`/arcade/${gameTitle}?difficulty=${option}`}>
+                  {transformLabel(option)}
+                </LinkButton>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default DropdownList;

--- a/src/components/DropdownList/index.ts
+++ b/src/components/DropdownList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DropdownList";

--- a/src/components/GameSelector/GameSelector.module.css
+++ b/src/components/GameSelector/GameSelector.module.css
@@ -1,0 +1,11 @@
+.container {
+  display: flex;
+  gap: 50px;
+  justify-self: center;
+}
+
+.gameOption {
+  width: 100%;
+  min-width: 150px;
+  text-align: center;
+}

--- a/src/components/GameSelector/GameSelector.tsx
+++ b/src/components/GameSelector/GameSelector.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+import styles from "./GameSelector.module.css";
+import DropdownList from "../DropdownList";
+import { transformLabel } from "@/utils";
+
+function GameSelector() {
+  const [isSelected, setIsSelected] = useState<string | null>(null);
+
+  function handleOnClick(id: string) {
+    if (id === isSelected) {
+      setIsSelected(null);
+      return;
+    }
+    setIsSelected(id);
+  }
+
+  const games = ["hangman", "snake", "matching-pairs"];
+
+  return (
+    <div className={styles.container}>
+      {games.map((game) => (
+        <DropdownList
+          gameTitle={game}
+          id={game}
+          key={game}
+          onClick={() => handleOnClick(game)}
+          isOpen={isSelected === game}
+          className={styles.gameOption}
+        >
+          {transformLabel(game)}
+        </DropdownList>
+      ))}
+    </div>
+  );
+}
+
+export default GameSelector;

--- a/src/components/GameSelector/index.ts
+++ b/src/components/GameSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GameSelector";

--- a/src/components/LinkButton/LinkButton.module.css
+++ b/src/components/LinkButton/LinkButton.module.css
@@ -1,0 +1,11 @@
+.linkButtonContainer {
+  background-color: buttonface;
+  padding-block: 1px;
+  padding-inline: 6px;
+  border-width: 2px;
+  border-style: outset;
+  border-color: buttonborder;
+  cursor: pointer;
+
+  text-align: center;
+}

--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import styles from "./LinkButton.module.css";
+
+type Props = {
+  href: string;
+  children: ReactNode;
+};
+
+function LinkButton({ href, children }: Props) {
+  return (
+    <Link href={href}>
+      <div className={styles.linkButtonContainer}>{children}</div>
+    </Link>
+  );
+}
+
+export default LinkButton;

--- a/src/components/LinkButton/index.ts
+++ b/src/components/LinkButton/index.ts
@@ -1,0 +1,1 @@
+export {default} from './LinkButton'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const DIFFICULTIES = ["easy", "medium", "hard"] as const;

--- a/src/features/hangman/HangmanGame.tsx
+++ b/src/features/hangman/HangmanGame.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import styles from "./HangmanGame.module.css";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import { isDifficulty } from "@/utils";
+import { Difficulty } from "@/types";
+import useCheckSearchParams from "@/hooks/useCheckSearchParams";
 
 import useHangman from "@/features/hangman/hooks/useHangman";
 import AttemptsCounter from "@/features/hangman/components/AttemptsCounter";
@@ -9,6 +15,8 @@ import WordBoard from "@/features/hangman/components/WordBoard";
 import RestartButton from "@/components/RestartButton";
 
 function HangmanGame() {
+  const selectedDifficulty = useCheckSearchParams();
+
   const {
     attempts,
     answer,
@@ -19,7 +27,7 @@ function HangmanGame() {
     handleGuess,
     restart,
     word,
-  } = useHangman();
+  } = useHangman(selectedDifficulty);
   return (
     <div className={styles.contentContainer}>
       <AttemptsCounter attempts={attempts} />

--- a/src/features/hangman/hooks/useHangman.ts
+++ b/src/features/hangman/hooks/useHangman.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 
 import { ATTEMPTS } from "../data";
-import type { Difficulty, LetterEntry } from "../types";
-import type { GameStatus } from "@/types";
+import type { LetterEntry } from "../types";
+import type { GameStatus, Difficulty } from "@/types";
 
 import useAttempts from "./useAttempts";
 import useWord from "./useWord";

--- a/src/features/hangman/hooks/useWord.ts
+++ b/src/features/hangman/hooks/useWord.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from "react";
 
 import { WORDS } from "../data";
 import { getRandomInt } from "../utils";
-import { Difficulty } from "../types";
+import { Difficulty } from "@/types";
 
 function useWord(difficulty: Difficulty) {
   const [usedWords, setUsedWords] = useState<string[]>([]);

--- a/src/features/hangman/types.ts
+++ b/src/features/hangman/types.ts
@@ -3,6 +3,4 @@ type LetterEntry = {
   isHidden: boolean;
 };
 
-type Difficulty = "easy" | "medium" | "hard";
-
-export type { LetterEntry, Difficulty };
+export type { LetterEntry };

--- a/src/features/matchingPairs/MatchingPairsGame.tsx
+++ b/src/features/matchingPairs/MatchingPairsGame.tsx
@@ -2,16 +2,20 @@
 
 import styles from "./MatchingPairsGame.module.css";
 
+import useCheckSearchParams from "@/hooks/useCheckSearchParams";
+
+import { MP_DIFFICULTY, CARD_POOL } from "./constants";
+
 import Card from "@/features/matchingPairs/components/Card";
 import CardsRow from "@/features/matchingPairs/components/CardsRow/CardsRow";
 import Timer from "@/features/matchingPairs/components/Timer";
 import RestartButton from "@/components/RestartButton";
 import useMatchingPairs from "@/features/matchingPairs/hooks/useMatchingPairs";
 
-const VALUES = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5];
-const TOTAL_TIME = 60;
-
 function MatchingPairsGame() {
+  const selectedDifficulty = useCheckSearchParams();
+  const { pairs, totalTime } = MP_DIFFICULTY[selectedDifficulty];
+
   const {
     deck,
     timeLeft,
@@ -23,7 +27,7 @@ function MatchingPairsGame() {
     isLost,
     isIdle,
     isRunning,
-  } = useMatchingPairs(VALUES, TOTAL_TIME);
+  } = useMatchingPairs(pairs, totalTime);
 
   return (
     <div className={styles.contentContainer}>

--- a/src/features/matchingPairs/components/Card/Card.module.css
+++ b/src/features/matchingPairs/components/Card/Card.module.css
@@ -1,6 +1,10 @@
 .card {
-  width: 80px;
-  height: 200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  width: 50px;
+  height: 100px;
   border: 1px solid white;
 }
 

--- a/src/features/matchingPairs/components/CardsRow/CardsRow.module.css
+++ b/src/features/matchingPairs/components/CardsRow/CardsRow.module.css
@@ -1,9 +1,10 @@
 .cardsRowContainer {
-  width: 440px;
+  width: 400px;
 }
 
 .cardsRow {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 10px;
 }

--- a/src/features/matchingPairs/constants.ts
+++ b/src/features/matchingPairs/constants.ts
@@ -1,0 +1,28 @@
+import type { Difficulty } from "@/types";
+
+const CARD_POOL = [
+  "🍎",
+  "🍋",
+  "🍓",
+  "🍉",
+  "🥑",
+  "🥕",
+  "🍪",
+  "🍩",
+  "🧩",
+  "🎈",
+  "🚗",
+  "🏀",
+  "🎸",
+  "🎧",
+  "📚",
+  "🖌️",
+] as const;
+
+const MP_DIFFICULTY = {
+  easy: { pairs: 6, totalTime: 45 },
+  medium: { pairs: 10, totalTime: 60 },
+  hard: { pairs: 15, totalTime: 75 },
+} as const satisfies Record<Difficulty, { pairs: number; totalTime: number }>;
+
+export { CARD_POOL, MP_DIFFICULTY };

--- a/src/features/matchingPairs/hooks/useDeck.ts
+++ b/src/features/matchingPairs/hooks/useDeck.ts
@@ -1,17 +1,19 @@
 import { useState, useEffect, useCallback, use } from "react";
 
-import { shuffleDeck, arrayToDeck } from "../utils";
+import { shuffleDeck, buildDeck } from "../utils";
 import type { MemoryCard } from "../types";
 
-function useDeck(values: any[]) {
-  const [deck, setDeck] = useState<MemoryCard[]>(() => arrayToDeck(values));
+function useDeck(pairCount: number, pool: readonly string[]) {
+  const [deck, setDeck] = useState<MemoryCard[]>(() =>
+    buildDeck(pairCount, pool)
+  );
 
   useEffect(() => {
     setDeck((prev) => shuffleDeck(prev));
   }, []);
 
   const resetDeck = useCallback(() => {
-    setDeck(shuffleDeck(deck));
+    setDeck(buildDeck(pairCount, pool));
   }, [deck]);
 
   return { deck, resetDeck };

--- a/src/features/matchingPairs/hooks/useMatchingPairs.ts
+++ b/src/features/matchingPairs/hooks/useMatchingPairs.ts
@@ -2,13 +2,14 @@ import { useState, useEffect } from "react";
 
 import type { GameStatus } from "@/types";
 import type { MemoryCard } from "../types";
+import { CARD_POOL } from "../constants";
 
 import useDeck from "./useDeck";
 import useTimer from "./useTimer";
 import { startIfIdle } from "@/utils";
 import { mapIds } from "../utils";
 
-function useMatchingPairs(values: number[], totalTime: number) {
+function useMatchingPairs(pairCount: number, totalTime: number) {
   const [gameStatus, setGameStatus] = useState<GameStatus>("idle");
 
   //cards state
@@ -16,7 +17,7 @@ function useMatchingPairs(values: number[], totalTime: number) {
   const [guessedCards, setGuessedCards] = useState<MemoryCard[]>([]);
   const [isBusy, setIsBusy] = useState(false);
 
-  const { deck, resetDeck } = useDeck(values);
+  const { deck, resetDeck } = useDeck(pairCount, CARD_POOL);
   const { timeLeft, resetTimer } = useTimer({
     gameStatus,
     setGameStatus,

--- a/src/features/matchingPairs/utils.ts
+++ b/src/features/matchingPairs/utils.ts
@@ -17,9 +17,18 @@ function arrayToDeck(array: any[]) {
   return objectList;
 }
 
+function buildDeck(pairCount: number, pool: readonly string[]) {
+  if (pairCount > pool.length) {
+    throw new Error("Not enough icons in CARD_POOL");
+  }
+  const chosen = shuffleDeck([...pool]).slice(0, pairCount);
+  const doubled = shuffleDeck([...chosen, ...chosen]); // duplicate & shuffle
+  return doubled.map((value) => ({ id: crypto.randomUUID(), value }));
+}
+
 function mapIds(cardsArray: MemoryCard[]) {
   const idsArray = cardsArray.map((card) => card.id);
   return idsArray;
 }
 
-export { shuffleDeck, arrayToDeck, mapIds };
+export { shuffleDeck, arrayToDeck, buildDeck, mapIds };

--- a/src/features/snake/SnakeGame.module.css
+++ b/src/features/snake/SnakeGame.module.css
@@ -8,3 +8,7 @@
 .gameBoard {
   border: 1px solid white;
 }
+
+.strictBorder {
+  border: 3px solid white;
+}

--- a/src/features/snake/SnakeGame.tsx
+++ b/src/features/snake/SnakeGame.tsx
@@ -3,27 +3,29 @@
 import React from "react";
 import styles from "./SnakeGame.module.css";
 
+import useCheckSearchParams from "@/hooks/useCheckSearchParams";
+
+import { CANVAS_DIMENSIONS, SNAKE_DIFFICULTY } from "./constants";
 import useSnake from "@/features/snake/hooks/useSnake";
 import useCanvas from "@/features/snake/hooks/useCanvas";
 
 import RestartButton from "@/components/RestartButton";
 
-const TILE = 15;
-const BOARD_W = 300;
-const BOARD_H = 300;
-const SPEED = 120;
-
 function SnakeGame() {
-  const game = useSnake(BOARD_W, BOARD_H, TILE, SPEED);
-  const canvasRef = useCanvas(game, BOARD_W, BOARD_H, TILE);
+  const selectedDifficulty = useCheckSearchParams();
+
+  const { speed, strictBorder } = SNAKE_DIFFICULTY[selectedDifficulty];
+  const { tile, boardW, boardH } = CANVAS_DIMENSIONS;
+  const game = useSnake(boardW, boardH, tile, speed, strictBorder);
+  const canvasRef = useCanvas(game, boardW, boardH, tile);
 
   return (
     <div className={styles.contentContainer}>
       <canvas
         ref={canvasRef}
-        width={BOARD_W}
-        height={BOARD_H}
-        className={styles.gameBoard}
+        width={boardW}
+        height={boardH}
+        className={`${styles.gameBoard} ${strictBorder && styles.strictBorder}`}
       ></canvas>
       <p>
         <strong>{game.isIdle && "Press any button to start the game"}</strong>

--- a/src/features/snake/constants.ts
+++ b/src/features/snake/constants.ts
@@ -1,0 +1,41 @@
+import { Difficulty } from "@/types";
+
+import type { Vector } from "./types";
+
+const CANVAS_DIMENSIONS = {
+  tile: 15,
+  boardW: 300,
+  boardH: 300,
+} as const;
+
+const SNAKE_INITIAL_POSITION: Vector[] = [
+  {
+    x: 45,
+    y: 45,
+  },
+  {
+    x: 30,
+    y: 45,
+  },
+  {
+    x: 15,
+    y: 45,
+  },
+] as const;
+const FOOD_INITIAL_POSITION: Vector = { x: 195, y: 45 } as const;
+
+const SNAKE_DIFFICULTY = {
+  easy: { speed: 120, strictBorder: false },
+  medium: { speed: 120, strictBorder: true },
+  hard: { speed: 80, strictBorder: true },
+} as const satisfies Record<
+  Difficulty,
+  { speed: number; strictBorder: boolean }
+>;
+
+export {
+  SNAKE_INITIAL_POSITION,
+  FOOD_INITIAL_POSITION,
+  CANVAS_DIMENSIONS,
+  SNAKE_DIFFICULTY,
+};

--- a/src/hooks/useCheckSearchParams.ts
+++ b/src/hooks/useCheckSearchParams.ts
@@ -1,0 +1,27 @@
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import { isDifficulty } from "@/utils";
+import { Difficulty } from "@/types";
+
+function useCheckSearchParams() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const tentativeDifficulty = searchParams.get("difficulty");
+  const selectedDifficulty: Difficulty = isDifficulty(tentativeDifficulty)
+    ? tentativeDifficulty
+    : "easy";
+
+  useEffect(() => {
+    if (!isDifficulty(tentativeDifficulty)) {
+      const params = new URLSearchParams(searchParams);
+      params.set("difficulty", selectedDifficulty);
+      router.replace(`?${params.toString()}`, { scroll: false });
+    }
+  }, [tentativeDifficulty, selectedDifficulty, router, searchParams]);
+
+  return selectedDifficulty;
+}
+
+export default useCheckSearchParams;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -29,6 +29,7 @@ body {
   }
 }
 
-h1 {
+h1,
+h2 {
   text-align: center;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+import { DIFFICULTIES } from "./constants";
+
 type GameStatus = "idle" | "running" | "won" | "lost";
 
-export type { GameStatus };
+type Difficulty = (typeof DIFFICULTIES)[number];
+
+export type { GameStatus, Difficulty };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import type { GameStatus } from "./types";
+import type { GameStatus, Difficulty } from "./types";
+import { DIFFICULTIES } from "./constants";
 
 function startIfIdle(
   gameStatus: GameStatus,
@@ -16,4 +17,10 @@ function upperCaseFirstLetter(string: string) {
   return string;
 }
 
-export { startIfIdle, transformLabel, upperCaseFirstLetter };
+function isDifficulty(value: unknown): value is Difficulty {
+  return (
+    typeof value === "string" && DIFFICULTIES.includes(value as Difficulty)
+  );
+}
+
+export { startIfIdle, transformLabel, upperCaseFirstLetter, isDifficulty };


### PR DESCRIPTION
* **Shared difficulty enum** and function to check it

* **URL handling**
  * New hook `useCheckSearchParams()`

  * Validates `?difficulty=` and silently normalises the URL.

* **UI**
  * Create `DropdownList` component

  * Wrapper API `<DropdownList>{trigger}</DropdownList>`

  * Closes on outside click.

* **Snake**

  * Constants moved to `@/features/snake/constants.ts`.

  * Per-difficulty config (`speed`, `strictBorder`).

  * Added wall-collision logic & border rendering.

* **Matching Pairs**

  * `MP_DIFFICULTY` table (pairs × time).

  * New `CARD_POOL` of emoji icons.

  * `buildDeck()` util + updated `useDeck`.

  * Deck size, timer and restart now honour difficulty.

* **Hangman**

  * Now consumes the shared Difficulty without change.

* **Misc**
  * Constants moved to `@/constants.ts`

  * Type-safe constants (`as const`, `satisfies Record<>`).

  * Minor dependency cleanup in hooks.