### PR TITLE
feat(matching-pairs): refactor game logic and improve accessibility

### DIFF
--- a/src/components/DropdownList/DropdownList.tsx
+++ b/src/components/DropdownList/DropdownList.tsx
@@ -47,6 +47,13 @@ function DropdownList({
       }`}
       id={id}
       onClick={onClick}
+      onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+        const targetIsContainer = e.currentTarget === e.target;
+        if (targetIsContainer && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
       tabIndex={0}
     >
       {children}

--- a/src/components/GameOver/GameOver.module.css
+++ b/src/components/GameOver/GameOver.module.css
@@ -26,3 +26,7 @@
   font-family: var(--font-press-start);
   font-size: 2rem;
 }
+
+.wonMessage {
+  font-size: 2rem;
+}

--- a/src/components/GameOver/GameOver.tsx
+++ b/src/components/GameOver/GameOver.tsx
@@ -12,7 +12,7 @@ function GameOver({ isWon, message, onClick }: Props) {
       <h2 className={styles.title}>Game Over</h2>
       {isWon && (
         <p>
-          <em>{"You won!"}</em>
+          <em className={styles.wonMessage}>You won!</em>
         </p>
       )}
       {message && <p>{message}</p>}

--- a/src/features/matchingPairs/components/Card/Card.module.css
+++ b/src/features/matchingPairs/components/Card/Card.module.css
@@ -3,7 +3,8 @@
   cursor: pointer;
 }
 
-.cardWrapper:hover {
+.cardWrapper:hover,
+.cardWrapper:focus {
   transform: scale(1.1);
   transition: transform 200ms ease-in;
 }
@@ -29,7 +30,8 @@
   backface-visibility: hidden;
 }
 
-.card:hover {
+.card:hover,
+.card:focus {
   box-shadow: 0 0 5px 2px var(--secondary);
 }
 

--- a/src/features/matchingPairs/components/Card/Card.tsx
+++ b/src/features/matchingPairs/components/Card/Card.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import styles from "./Card.module.css";
 
 type Props = {
@@ -13,13 +12,24 @@ function Card({ value, id, isFlipped, isMatched, onClick }: Props) {
   const flippingBack = !isFlipped && !isMatched;
 
   return (
-    <div className={styles.cardWrapper}>
+    <div
+      className={styles.cardWrapper}
+      tabIndex={0}
+      data-id={id}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+    >
       <div
         id={id}
+        data-value={value}
         className={`${styles.card} ${
           isFlipped || isMatched ? styles.flipped : ""
         } ${flippingBack ? styles.flippingBack : ""}`}
-        onClick={onClick}
       >
         {(isFlipped || isMatched) && (
           <img

--- a/src/features/matchingPairs/hooks/useDeck.ts
+++ b/src/features/matchingPairs/hooks/useDeck.ts
@@ -1,16 +1,18 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 
 import { buildDeck } from "../utils";
 import type { MemoryCard } from "../types";
 
 function useDeck(pairCount: number, pool: readonly string[]) {
-  const [deck, setDeck] = useState<MemoryCard[]>(() =>
-    buildDeck(pairCount, pool)
+  const initialDeck = useMemo(
+    () => buildDeck(pairCount, pool),
+    [pairCount, pool]
   );
+  const [deck, setDeck] = useState<MemoryCard[]>(initialDeck);
 
-  function resetDeck () {
+  function resetDeck() {
     setDeck(buildDeck(pairCount, pool));
-  };
+  }
 
   return { deck, resetDeck };
 }

--- a/src/features/matchingPairs/utils.ts
+++ b/src/features/matchingPairs/utils.ts
@@ -31,4 +31,19 @@ function mapIds(cardsArray: MemoryCard[]) {
   return idsArray;
 }
 
-export { shuffleDeck, arrayToDeck, buildDeck, mapIds };
+function checkTentativeWin(guessedCards: MemoryCard[], deck: MemoryCard[]) {
+  return guessedCards.length === deck.length;
+}
+
+function checkTentativeGuess(cardArray: MemoryCard[]) {
+  return cardArray[0].value === cardArray[1].value;
+}
+
+export {
+  shuffleDeck,
+  arrayToDeck,
+  buildDeck,
+  mapIds,
+  checkTentativeWin,
+  checkTentativeGuess,
+};


### PR DESCRIPTION
*Core changes*

- **refactor:** extract `checkTentativeGuess` and `checkTentativeWin` into `utils.ts`
- **refactor:** simplify `useMatchingPairs` by removing inline logic and using utility functions
- **refactor:** memoize `initialDeck` in `useDeck` to maintain stable card IDs across renders

*Accessibility*

- **feat:** make `Card` component keyboard-accessible
  - add `tabIndex`, `onKeyDown` for `Enter` and `Space`
  - add `data-id` and `data-value` attributes to support keyboard-based flipping
- **feat:** improve `DropdownList` keyboard behavior
  - trigger toggle only on `Enter`/`Space` when container is focused
  - allow dropdown options to be activated without closing the list

*Styles*

- **style:** add `:focus` states for `.cardWrapper` and `.card`
- **style:** add `.wonMessage` class to `GameOver.module.css` for styled win messages